### PR TITLE
Make M update step batched

### DIFF
--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -168,7 +168,7 @@ class LaplaceRFM(RecursiveFeatureMachine):
         samples_term = (K @ self.weights).reshape(n, c, 1)  # (n, p)  # (p, c)
 
         if self.diag:
-            G = (
+            centers_term = (
                 K  # (n, p)
                 @ (
                     self.weights.view(p, c, 1) * (self.centers * self.M).view(p, 1, d)
@@ -182,7 +182,7 @@ class LaplaceRFM(RecursiveFeatureMachine):
             samples_term = samples_term * (samples * self.M).reshape(n, 1, d)
 
         else:
-            G = (
+            centers_term = (
                 K  # (n, p)
                 @ (
                     self.weights.view(p, c, 1) * (self.centers @ self.M).view(p, 1, d)
@@ -195,7 +195,7 @@ class LaplaceRFM(RecursiveFeatureMachine):
 
             samples_term = samples_term * (samples @ self.M).reshape(n, 1, d)
 
-        G = (G - samples_term) / self.bandwidth  # (n, c, d)
+        G = (centers_term - samples_term) / self.bandwidth  # (n, c, d)
         
         # return quantity to be added to M. Division by len(samples) will be done in parent function.
         if self.diag:

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -118,9 +118,6 @@ class RecursiveFeatureMachine(torch.nn.Module):
     
     def fit_M(self, samples, batch_size=1000, verbose=False):
         """Applies EGOP to update the Mahalanobis matrix M."""
-        if self.diag:
-            raise NotImplementedError("Diagonal LaplaceRFM not implemented yet.")
-        
         n = len(samples)
         num_batches = (n // batch_size) + 1
         new_M = torch.zeros_like(self.M)

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -7,7 +7,7 @@ except ModuleNotFoundError:
     
 import torch, numpy as np
 from .kernels import laplacian_M, euclidean_distances_M
-from tqdm import tqdm
+from tqdm import tqdm, trange
 import hickle
 
 class RecursiveFeatureMachine(torch.nn.Module):
@@ -125,57 +125,77 @@ class LaplaceRFM(RecursiveFeatureMachine):
         super().__init__(**kwargs)
         self.bandwidth = bandwidth
         self.kernel = lambda x, z: laplacian_M(x, z, self.M, self.bandwidth) # must take 3 arguments (x, z, M)
-        
-
-    def update_M(self, samples):
-        
+    
+    def _update_M_batch(self, samples):
+        """Performs a batched update of M."""
         K = self.kernel(samples, self.centers)
 
         dist = euclidean_distances_M(samples, self.centers, self.M, squared=False)
         dist = torch.where(dist < 1e-10, torch.zeros(1, device=dist.device).float(), dist)
 
-        K = K/dist
-        K[K == float("Inf")] = 0.
+        K = K / dist
+        K[K == float("Inf")] = 0.0
 
         p, d = self.centers.shape
         p, c = self.weights.shape
         n, d = samples.shape
-        
-        samples_term = (
-                K # (n, p)
-                @ self.weights # (p, c)
-            ).reshape(n, c, 1)
-        
-        if self.diag:
+
+        samples_term = (K @ self.weights).reshape(n, c, 1)  # (n, p)  # (p, c)
+
+        if self.diag: # TODO: complete diagonal implementation
             centers_term = (
-                K # (n, p)
+                K  # (n, p)
                 @ (
                     self.weights.view(p, c, 1) * (self.centers * self.M).view(p, 1, d)
-                ).reshape(p, c*d) # (p, cd)
-            ).view(n, c, d) # (n, c, d)
+                ).reshape(
+                    p, c * d
+                )  # (p, cd)
+            ).view(
+                n, c, d
+            )  # (n, c, d)
 
             samples_term = samples_term * (samples * self.M).reshape(n, 1, d)
-            
-        else:        
-            centers_term = (
-                K # (n, p)
+
+        else:
+            G = (
+                K  # (n, p)
                 @ (
                     self.weights.view(p, c, 1) * (self.centers @ self.M).view(p, 1, d)
-                ).reshape(p, c*d) # (p, cd)
-            ).view(n, c, d) # (n, c, d)
+                ).reshape(
+                    p, c * d
+                )  # (p, cd)
+            ).view(
+                n, c, d
+            )  # (n, c, d)
 
             samples_term = samples_term * (samples @ self.M).reshape(n, 1, d)
 
-        G = (centers_term - samples_term) / self.bandwidth # (n, c, d)
+        G = (G - samples_term) / self.bandwidth  # (n, c, d)
         
-        if self.centering:
-            G = G - G.mean(0) # (n, c, d)
-        
-        if self.diag:
-            torch.einsum('ncd, ncd -> d', G, G)/len(samples)
-        else:
-            self.M = torch.einsum('ncd, ncD -> dD', G, G)/len(samples)
+        # return quantity to be added to M. Division by len(samples) will be done in parent function.
+        return torch.einsum("ncd, ncD -> dD", G, G)
 
+    def update_M(self, samples, batch_size=1000, verbose=False):
+        if self.diag:
+            raise NotImplementedError("Diagonal LaplaceRFM not implemented yet.")
+        
+        n = len(samples)
+        num_batches = (n // batch_size) + 1
+        new_M = torch.zeros_like(self.M)
+
+        pbar = trange(num_batches, disable=not verbose)
+
+        for i in pbar:
+            start = i * batch_size
+            end = min((i+1) * batch_size, n)
+            batch = samples[start:end]
+            new_M += self._update_M_batch(batch)
+        
+        self.M = new_M / n
+        del new_M
+
+        if self.centering:
+            self.M = self.M - self.M.mean(0)
 
 
 if __name__ == "__main__":

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -196,6 +196,8 @@ class LaplaceRFM(RecursiveFeatureMachine):
             samples_term = samples_term * (samples @ self.M).reshape(n, 1, d)
 
         G = (centers_term - samples_term) / self.bandwidth  # (n, c, d)
+
+        del centers_term, samples_term, K, dist
         
         # return quantity to be added to M. Division by len(samples) will be done in parent function.
         if self.diag:


### PR DESCRIPTION
## What does this do?
Modifies the `update_M()` function in `LaplaceRFM` to use batches of samples to update M instead of all samples. This greatly improves memory usage during training for which the M update step is the primary bottleneck (when using eigenpro). This is because the $\nabla f(x)$ computation was computing a large (n, c, d) matrix for the full training set (denoted as `G` in the code). Since we're just averaging over n, this can be split into batches.

## Any usability changes?
None, `update_M()` function signature works with everything else without changes. It does contain two new parameters which the use can change: `batch_size` (default `1000`) indicates the number of samples included in each batch, and `verbose` (default `False`) indicates whether to show a progress bar for the M update step which is useful when debugging with small batch sizes.

## How was this tested?
Using an NVIDIA A10 GPU with 24gb VRAM, the previous implementation maxed out at a samples/centers shape of 30,000 x 1,024. On a 6GB RTX 2060 this limit was 18,000 samples of the same dimensionality.

With a batched M update step, we can now run 70k samples on the A10 and 30k samples on the RTX 2060, almost doubling our maximum possible model size.
 