### PR TITLE
fix a bug in update_M when M is diagonal

### DIFF
--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -172,7 +172,7 @@ class LaplaceRFM(RecursiveFeatureMachine):
             G = G - G.mean(0) # (n, c, d)
         
         if self.diag:
-            torch.einsum('ncd, ncd -> d', G, G)/len(samples)
+            self.M = torch.einsum('ncd, ncd -> d', G, G)/len(samples)
         else:
             self.M = torch.einsum('ncd, ncD -> dD', G, G)/len(samples)
 


### PR DESCRIPTION
the updated M in the diagonal case was not stored in self.M, so M did not update (if you ran with diag=False, you could see that it doesn't change). I corrected it and ran the test with diag=True, and it started to work.