### PR TITLE
fix batched EGOP auto batch size

### DIFF
--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -129,14 +129,14 @@ class RecursiveFeatureMachine(torch.nn.Module):
         
         if M_batch_size is None: # calculate optimal batch size for batched EGOP
             curr_mem_use = torch.cuda.memory_allocated() # in bytes
-            BYTES_PER_SCALAR = self.M.element_size()
+            BYTES_PER_SCALAR = 8
             p, d = samples.shape
             c = labels.shape[-1]
             M_mem = (d if self.diag else d**2)
             centers_mem = (p * d)
-            mem_available = (self.mem_gb *1024**3) - curr_mem_use - (M_mem - centers_mem - 2*p*d) * BYTES_PER_SCALAR
+            mem_available = (self.mem_gb *1024**3) - curr_mem_use - (M_mem + centers_mem + 2*p*d) * BYTES_PER_SCALAR
             # maximum batch size limited by K, dist, centers_term, samples_term, and G
-            M_batch_size = mem_available // ((2*d + 2*p+3*c*d + 2)*BYTES_PER_SCALAR)
+            M_batch_size = mem_available // ((2*d + 2*p + 3*c*d + 2)*BYTES_PER_SCALAR)
         
         batches = torch.randperm(n).split(M_batch_size)
         for i, bids in tenumerate(batches):

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -120,6 +120,24 @@ class RecursiveFeatureMachine(torch.nn.Module):
             
         return final_mse
     
+    def _compute_optimal_M_batch(self, p, c, d, scalar_size=4):
+        """Computes the optimal batch size for EGOP."""
+        THREADS_PER_BLOCK = 512 # pytorch default
+        def tensor_mem_usage(numels):
+            """Calculates memory footprint of tensor based on number of elements."""
+            return np.ceil(scalar_size * numels / THREADS_PER_BLOCK) * THREADS_PER_BLOCK
+
+        def max_tensor_size(mem):
+            """Calculates maximum possible tensor given memory budget (bytes)."""
+            return int(np.floor(mem / THREADS_PER_BLOCK) * (THREADS_PER_BLOCK / scalar_size))
+
+        curr_mem_use = torch.cuda.memory_allocated() # in bytes
+        M_mem = tensor_mem_usage(d if self.diag else d**2)
+        centers_mem = tensor_mem_usage(p * d)
+        mem_available = (self.mem_gb *1024**3) - curr_mem_use - (M_mem + centers_mem) * scalar_size
+        M_batch_size = max_tensor_size((mem_available - 3*tensor_mem_usage(p) - tensor_mem_usage(p*c*d)) / (2*scalar_size*(1+p)))
+        return M_batch_size
+    
     def fit_M(self, samples, labels, M_batch_size=None, **kwargs):
         """Applies EGOP to update the Mahalanobis matrix M."""
         
@@ -127,20 +145,17 @@ class RecursiveFeatureMachine(torch.nn.Module):
         M = torch.zeros_like(self.M) if self.M is not None else (
             torch.zeros(d, dtype=samples.dtype) if self.diag else torch.zeros(d, d, dtype=samples.dtype))
         
-        if M_batch_size is None: # calculate optimal batch size for batched EGOP
-            curr_mem_use = torch.cuda.memory_allocated() # in bytes
-            BYTES_PER_SCALAR = 8
+        if M_batch_size is None: 
+            BYTES_PER_SCALAR = self.M.element_size()
             p, d = samples.shape
             c = labels.shape[-1]
-            M_mem = (d if self.diag else d**2)
-            centers_mem = (p * d)
-            mem_available = (self.mem_gb *1024**3) - curr_mem_use - (M_mem + centers_mem + 2*p*d) * BYTES_PER_SCALAR
-            # maximum batch size limited by K, dist, centers_term, samples_term, and G
-            M_batch_size = mem_available // ((2*d + 2*p + 3*c*d + 2)*BYTES_PER_SCALAR)
+            M_batch_size = self._compute_optimal_M_batch(p, c, d, scalar_size=BYTES_PER_SCALAR)
+            print(f"Using batch size of {M_batch_size}")
         
         batches = torch.randperm(n).split(M_batch_size)
         for i, bids in tenumerate(batches):
-            M += self.update_M(samples[bids])
+            torch.cuda.empty_cache()
+            M.add_(self.update_M(samples[bids]))
             
         self.M = M / n
         del M
@@ -178,7 +193,8 @@ class LaplaceRFM(RecursiveFeatureMachine):
         dist = euclidean_distances_M(samples, self.centers, self.M, squared=False)
         dist = torch.where(dist < 1e-10, torch.zeros(1, device=dist.device).float(), dist)
 
-        K = K / dist
+        K.div_(dist)
+        del dist
         K[K == float("Inf")] = 0.0
 
         p, d = self.centers.shape
@@ -217,7 +233,7 @@ class LaplaceRFM(RecursiveFeatureMachine):
 
         G = (centers_term - samples_term) / self.bandwidth  # (n, c, d)
 
-        del centers_term, samples_term, K, dist
+        del centers_term, samples_term, K
         
         # return quantity to be added to M. Division by len(samples) will be done in parent function.
         if self.diag:


### PR DESCRIPTION
Fixes automatic batch size calculation in `fit_M()`.

### Explanation
PyTorch allocates memory in blocks of 512 bytes (this is the default number of threads per CUDA block in PyTorch's implementation). Thus for any tensor with $b$ bytes per scalar and $x$ elements, 

$$h(x) = \left \lceil{\frac{bx}{512}}\right \rceil 512$$

When maximizing x and minimizing the memory footprint, we get $h(x) = bx$ where x is divisible by 512. Our inverse (converting a memory budget into maximal tensor size) is also:

$$t(x) = \left \lfloor{\frac{x}{512}}\right \rfloor \frac{512}{b}$$

In each `update_M` step, we achieve the following peak memory utilization (m,) (2x), (p,) (3x), (m,p) (2x), and (p,c,d). Let $M$ be the total memory used until the update step.

$$M = 2h(m) + 3h(p) + 2h(mp) + h(pcd)$$

Knowing our ideal $h(m) = bm$, we have: 
$$m = \frac{M - 3h(p) - h(pcd)}{2b(1+p)}$$

And converting this memory usage into a tensor size gives us:
$$m_{\text{max}} = t\left(\frac{M - 3h(p) - h(pcd)}{2b(1+p)}\right)$$
