### PR TITLE
Refactored and optimized L2 and L1 Laplace kernels

### DIFF
--- a/rfm/__init__.py
+++ b/rfm/__init__.py
@@ -1,3 +1,3 @@
 from .recursive_feature_machine import LaplaceRFM, GaussRFM, GeneralizedLaplaceRFM, NTKModel
-from .utils import matrix_sqrt
+from .utils import matrix_power
 __version__ = "0.1"

--- a/rfm/kernels.py
+++ b/rfm/kernels.py
@@ -399,6 +399,7 @@ def get_laplacian_gen_grad(
 
     # Backprop through linear layer: ∂k/∂x = ∂k/∂(Mx) @ M
     dk_dx = dk_dMx@sqrtM  # (batch, m, d_in)
+    print(f'{dk_dx.transpose(1,-1).shape=}, {alphas.shape=}')
     dk_dx_sum = dk_dx.transpose(1,-1)@alphas # nmd -> ndm, mc -> ndc
     return dk_dx_sum.transpose(1,-1) # ndc -> ncd    
 

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 import torch
 
+from rfm.kernels import get_laplacian_gen_grad
+
 
 class Kernel:
     def _get_kernel_matrix_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
@@ -79,6 +81,7 @@ class LaplaceKernel(Kernel):
     def __init__(self, bandwidth: float, exponent: float, eps: float = 1e-10):
         assert bandwidth > 0
         assert exponent > 0
+        assert eps > 0
         self.bandwidth = bandwidth
         self.exponent = exponent
         self.eps = eps  # this one is for numerical stability
@@ -130,19 +133,64 @@ class LaplaceKernel(Kernel):
         # return z_term - x_term
 
 
+class ProductLaplaceKernel(Kernel):
+    def __init__(self, bandwidth: float, exponent: float, eps: float = 1e-10):
+        assert bandwidth > 0
+        assert exponent > 0
+        assert eps > 0
+        self.bandwidth = bandwidth
+        self.exponent = exponent
+        self.eps = eps  # this one is for numerical stability
+
+    def _get_kernel_matrix_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        kernel_mat = torch.cdist(x, z, p=self.exponent)
+        kernel_mat.pow_(self.exponent)
+        kernel_mat.mul_(-((1./self.bandwidth)**self.exponent))
+        kernel_mat.exp_()
+        return kernel_mat
+
+    def _get_function_grad_impl(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor) -> torch.Tensor:
+        # return get_laplacian_gen_grad(z, x, sqrtM=None, v=self.exponent, L=self.bandwidth, alphas=coefs.t(), eps=self.eps).transpose(0, 1)
+
+        def compute_grad(out_idx: int):
+            z_cl = z.clone()
+            z_cl.requires_grad = True
+            dists = torch.cdist(x, z_cl, p=self.exponent) ** self.exponent
+            # masking
+            mask = dists >= self.eps
+
+            factor = -((1./self.bandwidth)**self.exponent)
+
+            # this is \sum_j f(z_j), so the derivative wrt z will be \nabla f(z_j) for all z_j
+            sum_f = torch.dot(coefs[out_idx, :], torch.exp(factor * (dists * mask)).sum(dim=1))
+            sum_f.backward()
+            return z_cl.grad
+        return torch.stack([compute_grad(i) for i in range(coefs.shape[0])], dim=0)
+
 if __name__ == '__main__':
+    # kernel = LaplaceKernel(bandwidth=2.0, exponent=1.0)
+    kernel = ProductLaplaceKernel(bandwidth=2.0, exponent=1.0)
+
+    n_samples = 2000
+    n_features = 100
+    x = torch.rand(n_samples, n_features)
+    coefs = torch.rand(1, n_samples)
+    kernel.get_agop(x, x, coefs)
+
+    print('here')
+
+
     import matplotlib.pyplot as plt
 
     x = torch.linspace(-2.0, 2.0, 5)[:, None]
     z = torch.linspace(-4.0, 4.0, 500)[:, None]
-    coefs = torch.as_tensor([1.0, 0.8, 0.4, -0.5, -2.0])[None, :]
-    kernel = LaplaceKernel(bandwidth=2.0, exponent=1.0)
+    coefs = torch.as_tensor([[1.0, 0.8, 0.4, -0.5, -2.0], [0.1, 0.2, 0.3, 0.4, 0.5]])
     # mat = None
     mat = torch.as_tensor([0.5])
     # mat = torch.as_tensor([[0.5]])
     f_values = coefs[0, :] @ kernel.get_kernel_matrix(x, z, mat)
     plt.plot(z[:, 0], f_values, 'tab:blue', label='function')
-    plt.plot(z, kernel.get_function_grads(x, z, coefs, mat).squeeze(0), 'tab:orange', label='gradient')
+    plt.plot(z, kernel.get_function_grads(x, z, coefs, mat)[0], 'tab:orange', label='gradient')
     plt.plot(0.5 * (z[1:, 0] + z[:-1, 0]), (f_values[1:] - f_values[:-1]) / (z[1:, 0] - z[:-1, 0]), color='tab:green',
              linestyle='--', label='finite diff')
     plt.legend()

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -113,7 +113,13 @@ class LaplaceKernel(Kernel):
         kernel_mat.mul_(-gamma * self.exponent)
 
         # now we want result[l, j, d] = \sum_i coefs[l, i] M[i, j] (z[j, d] - x[i, d])
-        return torch.einsum('li,ij,ijd->ljd', coefs, kernel_mat, (z[None, :, :] - x[:, None, :]))
+        z_term = (coefs @ kernel_mat)[:, :, None] * z[None, :, :]
+        x_term = kernel_mat.t() @ (coefs.t()[:, None, :] * x[:, :, None]).reshape(x.shape[0], -1)
+        x_term = x_term.reshape(x.shape[0], x.shape[1], coefs.shape[0]).permute(2, 0, 1)
+        return z_term - x_term
+
+        # this one is numerically stable but uses too much memory
+        # return torch.einsum('li,ij,ijd->ljd', coefs, kernel_mat, (z[None, :, :] - x[:, None, :]))
 
         # these computations would be more memory-efficient but are too unstable numerically
         # return (coefs @ kernel_mat)[:, :, None] * z[None, :, :] - torch.einsum('li,id,ij->ljd', coefs, x, kernel_mat)

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -7,7 +7,7 @@ class Kernel:
     def _get_kernel_matrix_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError()
 
-    def _get_kernel_grad_tensor_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+    def _get_function_grad_impl(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor) -> torch.Tensor:
         raise NotImplementedError()
 
     def _transform_m(self, x: torch.Tensor, mat: Optional[torch.Tensor] = None) -> torch.Tensor:
@@ -44,43 +44,19 @@ class Kernel:
         # todo: only compute certain blocks?
         return self.get_kernel_matrix(x, x, mat)
 
-    def get_kernel_grad_tensor(self, x: torch.Tensor, z: torch.Tensor,
-                               mat: Optional[torch.Tensor] = None) -> torch.Tensor:
-        """
-        Return the tensor of kernel matrix gradients wrt the second argument.
-        :param x: Matrix of shape (n_x, d_in)
-        :param z: Matrix of shape (n_z, d_in)
-        :param mat: Matrix of shape (d_in, d_out) or vector of shape (d_in)
-        :return: Should return a tensor of shape (n_x, n_z, d_in).
-        """
-        raw_deriv_tensor = self._get_kernel_grad_tensor_impl(self._transform_m(x, mat),
-                                                             self._transform_m(z, mat))
-
-        if mat is not None:
-            if len(mat.shape) == 1:
-                return raw_deriv_tensor * mat[None, None, :]
-            elif len(mat.shape) == 2:
-                return torch.einsum('xzd,di->xzi', raw_deriv_tensor, mat)
-            else:
-                raise ValueError(f'm_matrix should have one or two dimensions, but got shape {mat.shape}')
-
-        return raw_deriv_tensor
-
     def get_function_grads(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
                            mat: Optional[torch.Tensor] = None) -> torch.Tensor:
         """
-        Return the matrix of function gradients at points z. The function is given by \sum_i coefs[i] * k(x[i], \cdot).
-        :param x:
-        :param z:
-        :param coefs:
-        :param mat: sqrtM matrix.
-        :return:
+        Return the matrix of function gradients at points z.
+        The function is given by \sum_i coefs[i] * k(x[i], \cdot).
+        :param x: Matrix of shape (n_x, d_in)
+        :param z: Matrix of shape (n_z, d_in)
+        :param coefs: Vector of shape (n_x,)
+        :param mat: Matrix of shape (d_in, d_out) or vector of shape (d_in)
+        :return: Should return a tensor of shape (n_z, d_in).
         """
-        # optimization: don't apply m_matrix inside the grad tensor computation,
-        # only apply it after summing over coefficients
-        deriv_tensor = self.get_kernel_grad_tensor(self._transform_m(x, mat), self._transform_m(z, mat))
-        # gradients of the function at points z
-        return self._transform_m(torch.einsum('x,xzd->zd', coefs, deriv_tensor), mat)
+        grads = self._get_function_grad_impl(self._transform_m(x, mat), self._transform_m(z, mat), coefs)
+        return self._transform_m(grads, mat)
 
     def get_agop(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
                  mat: Optional[torch.Tensor] = None) -> torch.Tensor:
@@ -105,11 +81,11 @@ class LaplaceKernel(Kernel):
         kernel_mat.clamp_(min=0)
         if self.exponent != 1.0:
             kernel_mat.pow_(self.exponent)
-        kernel_mat.mul_(-1./self.bandwidth)
+        kernel_mat.mul_(-1. / self.bandwidth)
         kernel_mat.exp_()
         return kernel_mat
 
-    def _get_func_grad_impl(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor) -> torch.Tensor:
+    def _get_function_grad_impl(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor) -> torch.Tensor:
         dists = torch.cdist(x, z)
         dists.clamp_(min=0)
 
@@ -118,20 +94,38 @@ class LaplaceKernel(Kernel):
         # therefore, setting f(z) = \sum_i coefs[i] k(x[i], z), we have
         # \grad f(z[j]) = \sum_i coefs[i] M[i, j] (z[j] - x[i]),
         # where M[i, j] = -\gamma \beta k(x[i], z[j]) \|x[i] - z[j]\|^{\beta - 2}
-        gamma = 1./self.bandwidth
+        gamma = 1. / self.bandwidth
         kernel_mat = dists ** self.exponent
         kernel_mat.mul_(-gamma)
         kernel_mat.exp_()
 
         # now compute M
+        # todo: is this good enough for the masking?
         dists.clamp_(min=1e-8)  # todo: make configurable?
-        dists.pow_(self.exponent-2)
+        dists.pow_(self.exponent - 2)
         kernel_mat.mul_(dists)
-        kernel_mat.mul_(-gamma*self.exponent)
+        kernel_mat.mul_(-gamma * self.exponent)
 
         # now we want result[j, d] = \sum_i coefs[i] grad_mat[i, j] (z[j, d] - x[i, d])
         kernel_mat.mul_(coefs[:, None])
 
-        return kernel_mat.sum(dim=0)[:, None] * z - kernel_mat @ x
+        return kernel_mat.sum(dim=0)[:, None] * z - kernel_mat.t() @ x
 
 
+if __name__ == '__main__':
+    import matplotlib.pyplot as plt
+
+    x = torch.linspace(-2.0, 2.0, 5)[:, None]
+    z = torch.linspace(-4.0, 4.0, 500)[:, None]
+    coefs = torch.as_tensor([1.0, 0.8, 0.4, -0.5, -2.0])
+    kernel = LaplaceKernel(bandwidth=2.0, exponent=1.2)
+    # mat = None
+    mat = torch.as_tensor([0.5])
+    # mat = torch.as_tensor([[0.5]])
+    f_values = coefs @ kernel.get_kernel_matrix(x, z, mat)
+    plt.plot(z[:, 0], f_values, 'tab:blue', label='function')
+    plt.plot(z, kernel.get_function_grads(x, z, coefs, mat), 'tab:orange', label='gradient')
+    plt.plot(0.5 * (z[1:, 0] + z[:-1, 0]), (f_values[1:] - f_values[:-1]) / (z[1:, 0] - z[:-1, 0]), color='tab:green',
+             linestyle='--', label='finite diff')
+    plt.legend()
+    plt.show()

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -48,25 +48,31 @@ class Kernel:
                            mat: Optional[torch.Tensor] = None) -> torch.Tensor:
         """
         Return the matrix of function gradients at points z.
-        The function is given by \sum_i coefs[i] * k(x[i], \cdot).
+        The function is given by f_l(\cdot) = \sum_i coefs[l, i] * k(x[i], \cdot).
         :param x: Matrix of shape (n_x, d_in)
         :param z: Matrix of shape (n_z, d_in)
-        :param coefs: Vector of shape (n_x,)
+        :param coefs: Vector of shape (f, n_x) where f is the number of functions
         :param mat: Matrix of shape (d_in, d_out) or vector of shape (d_in)
-        :return: Should return a tensor of shape (n_z, d_in).
+        :return: Should return a tensor of shape (f, n_z, d_in).
         """
         grads = self._get_function_grad_impl(self._transform_m(x, mat), self._transform_m(z, mat), coefs)
         return self._transform_m(grads, mat)
 
     def get_agop(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
                  mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        # see get_function_grads
         f_grads = self.get_function_grads(x, z, coefs, mat)
-        return f_grads.t() @ f_grads
+        # merge output and n_z dims
+        f_grads = f_grads.reshape(-1, f_grads.shape[-1])
+        return f_grads.transpose(-1, -2) @ f_grads
 
     def get_agop_diag(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
                       mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        # see get_function_grads
         f_grads = self.get_function_grads(x, z, coefs, mat)
-        return f_grads.square().sum(dim=0)
+        # merge output and n_z dims
+        f_grads = f_grads.reshape(-1, f_grads.shape[-1])
+        return f_grads.square().sum(dim=-2)
 
 
 class LaplaceKernel(Kernel):
@@ -91,8 +97,8 @@ class LaplaceKernel(Kernel):
 
         # gradient of k(x, z) = exp(-\gamma \|x - z\|^\beta) wrt z  (where \beta = self.exponent)
         # is -\gamma k(x, z) \beta \|x - z\|^{\beta - 1} (z-x)/\|x-z\| = -\gamma \beta k(x, z) \|x - z\|^{\beta-2} (z-x)
-        # therefore, setting f(z) = \sum_i coefs[i] k(x[i], z), we have
-        # \grad f(z[j]) = \sum_i coefs[i] M[i, j] (z[j] - x[i]),
+        # therefore, setting f_l (z) = \sum_i coefs[l, i] k(x[i], z), we have
+        # \grad f_l(z[j]) = \sum_i coefs[l, i] M[i, j] (z[j] - x[i]),
         # where M[i, j] = -\gamma \beta k(x[i], z[j]) \|x[i] - z[j]\|^{\beta - 2}
         gamma = 1. / self.bandwidth
         kernel_mat = dists ** self.exponent
@@ -106,10 +112,12 @@ class LaplaceKernel(Kernel):
         kernel_mat.mul_(dists)
         kernel_mat.mul_(-gamma * self.exponent)
 
-        # now we want result[j, d] = \sum_i coefs[i] grad_mat[i, j] (z[j, d] - x[i, d])
-        kernel_mat.mul_(coefs[:, None])
+        # now we want result[l, j, d] = \sum_i coefs[l, i] M[i, j] (z[j, d] - x[i, d])
+        return torch.einsum('li,ij,ijd->ljd', coefs, kernel_mat, (z[None, :, :] - x[:, None, :]))
 
-        return kernel_mat.sum(dim=0)[:, None] * z - kernel_mat.t() @ x
+        # these computations would be more memory-efficient but are too unstable numerically
+        # return (coefs @ kernel_mat)[:, :, None] * z[None, :, :] - torch.einsum('li,id,ij->ljd', coefs, x, kernel_mat)
+        # return torch.einsum('li,ij,jd->ljd', coefs, kernel_mat, z) - torch.einsum('li,ij,id->ljd', coefs, kernel_mat, x)
 
 
 if __name__ == '__main__':
@@ -117,14 +125,14 @@ if __name__ == '__main__':
 
     x = torch.linspace(-2.0, 2.0, 5)[:, None]
     z = torch.linspace(-4.0, 4.0, 500)[:, None]
-    coefs = torch.as_tensor([1.0, 0.8, 0.4, -0.5, -2.0])
-    kernel = LaplaceKernel(bandwidth=2.0, exponent=1.2)
+    coefs = torch.as_tensor([1.0, 0.8, 0.4, -0.5, -2.0])[None, :]
+    kernel = LaplaceKernel(bandwidth=2.0, exponent=1.0)
     # mat = None
     mat = torch.as_tensor([0.5])
     # mat = torch.as_tensor([[0.5]])
-    f_values = coefs @ kernel.get_kernel_matrix(x, z, mat)
+    f_values = coefs[0, :] @ kernel.get_kernel_matrix(x, z, mat)
     plt.plot(z[:, 0], f_values, 'tab:blue', label='function')
-    plt.plot(z, kernel.get_function_grads(x, z, coefs, mat), 'tab:orange', label='gradient')
+    plt.plot(z, kernel.get_function_grads(x, z, coefs, mat).squeeze(0), 'tab:orange', label='gradient')
     plt.plot(0.5 * (z[1:, 0] + z[:-1, 0]), (f_values[1:] - f_values[:-1]) / (z[1:, 0] - z[:-1, 0]), color='tab:green',
              linestyle='--', label='finite diff')
     plt.legend()

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -150,26 +150,36 @@ class ProductLaplaceKernel(Kernel):
         return kernel_mat
 
     def _get_function_grad_impl(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor) -> torch.Tensor:
+        def forward_func(z):
+            dists = torch.cdist(x, z, p=self.exponent) ** self.exponent
+            factor = -((1. / self.bandwidth) ** self.exponent)
+            # this is \sum_j f(z_j), so the derivative wrt z will be jacobian(f)(z_j) for all z_j
+            return coefs @ torch.exp(factor * (dists * (dists >= self.eps))).sum(dim=1)
+
+        return torch.func.jacrev(forward_func)(z)
+
         # return get_laplacian_gen_grad(z, x, sqrtM=None, v=self.exponent, L=self.bandwidth, alphas=coefs.t(), eps=self.eps).transpose(0, 1)
 
-        def compute_grad(out_idx: int):
-            z_cl = z.clone()
-            z_cl.requires_grad = True
-            dists = torch.cdist(x, z_cl, p=self.exponent) ** self.exponent
-            # masking
-            mask = dists >= self.eps
+        # def compute_grad(out_idx: int):
+        #     z_cl = z.clone()
+        #     z_cl.requires_grad = True
+        #     dists = torch.cdist(x, z_cl, p=self.exponent) ** self.exponent
+        #     # masking
+        #     mask = dists >= self.eps
+        #
+        #     factor = -((1./self.bandwidth)**self.exponent)
+        #
+        #     # this is \sum_j f(z_j), so the derivative wrt z will be \nabla f(z_j) for all z_j
+        #     sum_f = torch.dot(coefs[out_idx, :], torch.exp(factor * (dists * mask)).sum(dim=1))
+        #     sum_f.backward()
+        #     return z_cl.grad
+        # return torch.stack([compute_grad(i) for i in range(coefs.shape[0])], dim=0)
 
-            factor = -((1./self.bandwidth)**self.exponent)
 
-            # this is \sum_j f(z_j), so the derivative wrt z will be \nabla f(z_j) for all z_j
-            sum_f = torch.dot(coefs[out_idx, :], torch.exp(factor * (dists * mask)).sum(dim=1))
-            sum_f.backward()
-            return z_cl.grad
-        return torch.stack([compute_grad(i) for i in range(coefs.shape[0])], dim=0)
 
 if __name__ == '__main__':
     # kernel = LaplaceKernel(bandwidth=2.0, exponent=1.0)
-    kernel = ProductLaplaceKernel(bandwidth=2.0, exponent=1.0)
+    kernel = ProductLaplaceKernel(bandwidth=2.0, exponent=1.2)
 
     n_samples = 2000
     n_features = 100

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -76,11 +76,12 @@ class Kernel:
 
 
 class LaplaceKernel(Kernel):
-    def __init__(self, bandwidth: float, exponent: float):
+    def __init__(self, bandwidth: float, exponent: float, eps: float = 1e-10):
         assert bandwidth > 0
         assert exponent > 0
         self.bandwidth = bandwidth
         self.exponent = exponent
+        self.eps = eps  # this one is for numerical stability
 
     def _get_kernel_matrix_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
         kernel_mat = torch.cdist(x, z)
@@ -106,24 +107,27 @@ class LaplaceKernel(Kernel):
         kernel_mat.exp_()
 
         # now compute M
-        # todo: is this good enough for the masking?
-        dists.clamp_(min=1e-8)  # todo: make configurable?
+        mask = dists>=self.eps
+        dists.clamp_(min=self.eps)
         dists.pow_(self.exponent - 2)
         kernel_mat.mul_(dists)
+        kernel_mat.mul_(mask)  # this is very important for numerical stability
         kernel_mat.mul_(-gamma * self.exponent)
 
         # now we want result[l, j, d] = \sum_i coefs[l, i] M[i, j] (z[j, d] - x[i, d])
-        z_term = (coefs @ kernel_mat)[:, :, None] * z[None, :, :]
-        x_term = kernel_mat.t() @ (coefs.t()[:, None, :] * x[:, :, None]).reshape(x.shape[0], -1)
-        x_term = x_term.reshape(x.shape[0], x.shape[1], coefs.shape[0]).permute(2, 0, 1)
-        return z_term - x_term
 
-        # this one is numerically stable but uses too much memory
+        # this one uses too much memory
         # return torch.einsum('li,ij,ijd->ljd', coefs, kernel_mat, (z[None, :, :] - x[:, None, :]))
 
-        # these computations would be more memory-efficient but are too unstable numerically
         # return (coefs @ kernel_mat)[:, :, None] * z[None, :, :] - torch.einsum('li,id,ij->ljd', coefs, x, kernel_mat)
-        # return torch.einsum('li,ij,jd->ljd', coefs, kernel_mat, z) - torch.einsum('li,ij,id->ljd', coefs, kernel_mat, x)
+        return torch.einsum('li,ij,jd->ljd', coefs, kernel_mat, z) - torch.einsum('li,ij,id->ljd', coefs, kernel_mat, x)
+
+        # this one is a manual version of the two-einsum version above,
+        # analogous to the old implementation but with some transposed dimensions
+        # z_term = (coefs @ kernel_mat)[:, :, None] * z[None, :, :]
+        # x_term = kernel_mat.t() @ (coefs.t()[:, None, :] * x[:, :, None]).reshape(x.shape[0], -1)
+        # x_term = x_term.reshape(x.shape[0], x.shape[1], coefs.shape[0]).permute(2, 0, 1)
+        # return z_term - x_term
 
 
 if __name__ == '__main__':

--- a/rfm/kernels_new.py
+++ b/rfm/kernels_new.py
@@ -1,0 +1,137 @@
+from typing import Optional
+
+import torch
+
+
+class Kernel:
+    def _get_kernel_matrix_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def _get_kernel_grad_tensor_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError()
+
+    def _transform_m(self, x: torch.Tensor, mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """
+        Applies the given transformation matrix to x.
+        :param x: Points of shape (n, d_in).
+        :param mat: Matrix of shape (d_in, d_out) or vector of shape (d_in,) or None.
+            A vector will be interpreted as a diagonal matrix, and None as the identity matrix.
+        :return: Tensor of shape (n, d_out), where d_out=d_in in case mat is a vector or None.
+        """
+        if mat is not None:
+            if len(mat.shape) == 1:
+                # diagonal
+                x = x * mat[None, :]
+            elif len(mat.shape) == 2:
+                x = x @ mat
+            else:
+                raise ValueError(f'm_matrix should have one or two dimensions, but got shape {mat.shape}')
+        return x
+
+    def get_kernel_matrix(self, x: torch.Tensor, z: torch.Tensor,
+                          mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """
+        Get the kernel matrix (k(x[i, :], z[j, :]))_{i,j}
+        :param x: Points of shape (n_x, d_in).
+        :param z: Points of shape (n_z, d_in).
+        :param mat: Matrix of shape (d_in, d_out) or vector of shape (d_in,) or None. This will be applied to x and z.
+        Corresponds to sqrtM in RFM.
+        :return: The kernel matrix of shape (n_x, n_z).
+        """
+        return self._get_kernel_matrix_impl(self._transform_m(x, mat), self._transform_m(z, mat))
+
+    def get_kernel_matrix_symm(self, x: torch.Tensor, mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        # todo: only compute certain blocks?
+        return self.get_kernel_matrix(x, x, mat)
+
+    def get_kernel_grad_tensor(self, x: torch.Tensor, z: torch.Tensor,
+                               mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """
+        Return the tensor of kernel matrix gradients wrt the second argument.
+        :param x: Matrix of shape (n_x, d_in)
+        :param z: Matrix of shape (n_z, d_in)
+        :param mat: Matrix of shape (d_in, d_out) or vector of shape (d_in)
+        :return: Should return a tensor of shape (n_x, n_z, d_in).
+        """
+        raw_deriv_tensor = self._get_kernel_grad_tensor_impl(self._transform_m(x, mat),
+                                                             self._transform_m(z, mat))
+
+        if mat is not None:
+            if len(mat.shape) == 1:
+                return raw_deriv_tensor * mat[None, None, :]
+            elif len(mat.shape) == 2:
+                return torch.einsum('xzd,di->xzi', raw_deriv_tensor, mat)
+            else:
+                raise ValueError(f'm_matrix should have one or two dimensions, but got shape {mat.shape}')
+
+        return raw_deriv_tensor
+
+    def get_function_grads(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
+                           mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        """
+        Return the matrix of function gradients at points z. The function is given by \sum_i coefs[i] * k(x[i], \cdot).
+        :param x:
+        :param z:
+        :param coefs:
+        :param mat: sqrtM matrix.
+        :return:
+        """
+        # optimization: don't apply m_matrix inside the grad tensor computation,
+        # only apply it after summing over coefficients
+        deriv_tensor = self.get_kernel_grad_tensor(self._transform_m(x, mat), self._transform_m(z, mat))
+        # gradients of the function at points z
+        return self._transform_m(torch.einsum('x,xzd->zd', coefs, deriv_tensor), mat)
+
+    def get_agop(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
+                 mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        f_grads = self.get_function_grads(x, z, coefs, mat)
+        return f_grads.t() @ f_grads
+
+    def get_agop_diag(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor,
+                      mat: Optional[torch.Tensor] = None) -> torch.Tensor:
+        f_grads = self.get_function_grads(x, z, coefs, mat)
+        return f_grads.square().sum(dim=0)
+
+
+class LaplaceKernel(Kernel):
+    def __init__(self, bandwidth: float, exponent: float):
+        assert bandwidth > 0
+        assert exponent > 0
+        self.bandwidth = bandwidth
+        self.exponent = exponent
+
+    def _get_kernel_matrix_impl(self, x: torch.Tensor, z: torch.Tensor) -> torch.Tensor:
+        kernel_mat = torch.cdist(x, z)
+        kernel_mat.clamp_(min=0)
+        if self.exponent != 1.0:
+            kernel_mat.pow_(self.exponent)
+        kernel_mat.mul_(-1./self.bandwidth)
+        kernel_mat.exp_()
+        return kernel_mat
+
+    def _get_func_grad_impl(self, x: torch.Tensor, z: torch.Tensor, coefs: torch.Tensor) -> torch.Tensor:
+        dists = torch.cdist(x, z)
+        dists.clamp_(min=0)
+
+        # gradient of k(x, z) = exp(-\gamma \|x - z\|^\beta) wrt z  (where \beta = self.exponent)
+        # is -\gamma k(x, z) \beta \|x - z\|^{\beta - 1} (z-x)/\|x-z\| = -\gamma \beta k(x, z) \|x - z\|^{\beta-2} (z-x)
+        # therefore, setting f(z) = \sum_i coefs[i] k(x[i], z), we have
+        # \grad f(z[j]) = \sum_i coefs[i] M[i, j] (z[j] - x[i]),
+        # where M[i, j] = -\gamma \beta k(x[i], z[j]) \|x[i] - z[j]\|^{\beta - 2}
+        gamma = 1./self.bandwidth
+        kernel_mat = dists ** self.exponent
+        kernel_mat.mul_(-gamma)
+        kernel_mat.exp_()
+
+        # now compute M
+        dists.clamp_(min=1e-8)  # todo: make configurable?
+        dists.pow_(self.exponent-2)
+        kernel_mat.mul_(dists)
+        kernel_mat.mul_(-gamma*self.exponent)
+
+        # now we want result[j, d] = \sum_i coefs[i] grad_mat[i, j] (z[j, d] - x[i, d])
+        kernel_mat.mul_(coefs[:, None])
+
+        return kernel_mat.sum(dim=0)[:, None] * z - kernel_mat @ x
+
+

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -1,3 +1,4 @@
+from rfm.kernels_new import Kernel
 from .eigenpro import KernelModel
     
 import torch, numpy as np
@@ -52,7 +53,6 @@ class RecursiveFeatureMachine(torch.nn.Module):
                                                        **kwargs)
         else:
             self.weights = self.fit_predictor_lstsq(centers, targets, class_weight=class_weight, solver=solver)
-
 
     def fit_predictor_lstsq(self, centers, targets, class_weight=None, solver='solve'):
         centers = centers.to(self.device)
@@ -111,7 +111,7 @@ class RecursiveFeatureMachine(torch.nn.Module):
             solver='solve', **kwargs):
                 
         self.fit_using_eigenpro = (method.lower()=='eigenpro')
-        use_sqrtM = self.kernel_type in ['laplacian_gen']
+        use_sqrtM = self.kernel_type in ['laplacian_gen', 'generic']
         
         if iters is None:
             iters = self.iters
@@ -425,6 +425,30 @@ class GeneralizedLaplaceRFM(RecursiveFeatureMachine):
                                     self.M_batch_size, 
                                     self.diag
                                     )
+        return agop
+
+
+class GenericRFM(RecursiveFeatureMachine):
+    def __init__(self, kernel: Kernel, agop_power=0.5, **kwargs):
+        super().__init__(**kwargs)
+        self.kernel_obj = kernel
+        self.kernel = lambda x, z: self.kernel_obj.get_kernel_matrix(x, z, self.sqrtM)
+        self.kernel_type = 'generic'
+        self.agop_power = agop_power
+
+    def update_M(self, samples, p_batch_size):
+        if self.M is None:
+            if self.diag:
+                self.M = torch.ones(samples.shape[-1], device=samples.device, dtype=samples.dtype)
+                self.sqrtM = torch.ones(samples.shape[-1], device=samples.device, dtype=samples.dtype)
+            else:
+                self.M = torch.eye(samples.shape[-1], device=samples.device, dtype=samples.dtype)
+                self.sqrtM = torch.eye(samples.shape[-1], device=samples.device, dtype=samples.dtype)
+
+        samples = samples.to(self.device)
+        self.centers = self.centers.to(self.device)
+        agop_func = self.kernel_obj.get_agop_diag if self.diag else self.kernel_obj.get_agop
+        agop = agop_func(x=self.centers, z=samples, coefs=self.weights.t(), mat=self.sqrtM)
         return agop
 
 

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -258,6 +258,8 @@ class RecursiveFeatureMachine(torch.nn.Module):
             return lambda x, z, M=self.M, bandwidth=self.bandwidth: gaussian_M(x, z, M, bandwidth)
         elif self.kernel_type == 'ntk':
             return lambda x, z, sqrtM=self.sqrtM: ntk_kernel(x, z, sqrtM)
+        elif self.kernel_type == 'generic':
+            return lambda x, z, sqrtM=self.sqrtM, k=self.kernel_obj: k.get_kernel_matrix(x, z, sqrtM)
         else:
             raise ValueError(f"Missing kernel type: {self.kernel_type}")
     

--- a/rfm/recursive_feature_machine.py
+++ b/rfm/recursive_feature_machine.py
@@ -363,6 +363,7 @@ class LaplaceRFM(RecursiveFeatureMachine):
         if self.diag:
             temp = 0
             for p_batch in torch.arange(p).split(p_batch_size):
+                # temp[j,l,d] += \sum_i M[j,i] * coefs[i,l] * x[i,d]
                 temp += K[:, p_batch] @ ( # (n, len(p_batch))
                     self.weights[p_batch,:].view(len(p_batch), c, 1) * (self.centers[p_batch,:] * self.M).view(len(p_batch), 1, d)
                 ).reshape(
@@ -370,6 +371,8 @@ class LaplaceRFM(RecursiveFeatureMachine):
                 )  # (len(p_batch), cd)
             
             centers_term = temp.view(n, c, d)
+
+            # M[j, i] * coefs[i, l] * z[j, d]
             samples_term = samples_term * (samples * self.M).reshape(n, 1, d)
 
         else:

--- a/test.py
+++ b/test.py
@@ -1,7 +1,7 @@
 import numpy as np
 import torch
-from rfm import LaplaceRFM
-from rfm.kernels_new import LaplaceKernel
+from rfm import LaplaceRFM, GeneralizedLaplaceRFM
+from rfm.kernels_new import LaplaceKernel, ProductLaplaceKernel
 from rfm.recursive_feature_machine import GenericRFM
 
 np.random.seed(0)
@@ -15,10 +15,13 @@ def fstar(X):
         ).float()
 
 # model = LaplaceRFM(bandwidth=1., diag=True)
-model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=1.0), diag=True)
+# model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=1.0), diag=True)
+# model = GeneralizedLaplaceRFM(bandwidth=50., exponent=1.0, diag=True)
+model = GenericRFM(ProductLaplaceKernel(bandwidth=10., exponent=1.0), diag=True)
 
-n = 4000 # samples
-d = 100  # dimension
+
+n = 1000 # samples
+d = 30  # dimension
 c = 2    # classes
 
 X_train = torch.randn(n, d)

--- a/test.py
+++ b/test.py
@@ -3,9 +3,12 @@ import torch
 from rfm import LaplaceRFM, GeneralizedLaplaceRFM
 from rfm.kernels_new import LaplaceKernel, ProductLaplaceKernel
 from rfm.recursive_feature_machine import GenericRFM
+import time
 
 np.random.seed(0)
 torch.manual_seed(0)
+
+M_batch_size = 2048
 
 def fstar(X):
     return torch.cat([
@@ -17,11 +20,11 @@ def fstar(X):
 # model = LaplaceRFM(bandwidth=1., diag=True)
 # model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=1.0), diag=True)
 # model = GeneralizedLaplaceRFM(bandwidth=50., exponent=1.0, diag=True)
-model = GenericRFM(ProductLaplaceKernel(bandwidth=10., exponent=1.0), diag=True)
+model = GenericRFM(ProductLaplaceKernel(bandwidth=50., exponent=1.0), diag=True)
 
 
-n = 1000 # samples
-d = 30  # dimension
+n = 4000 # samples
+d = 100  # dimension
 c = 2    # classes
 
 X_train = torch.randn(n, d)
@@ -29,10 +32,15 @@ X_test = torch.randn(n, d)
 y_train = fstar(X_train)
 y_test = fstar(X_test)
 
+start_time = time.time()
+
 model.fit(
     (X_train, y_train), 
     (X_test, y_test), 
     loader=False, 
     iters=5,
-    classif=False
+    classif=False,
+    M_batch_size=M_batch_size,
 )
+
+print(f'Time: {time.time()-start_time:g} s')

--- a/test.py
+++ b/test.py
@@ -14,8 +14,8 @@ def fstar(X):
     	    axis=1
         ).float()
 
-model = LaplaceRFM(bandwidth=1., diag=False)
-# model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=0.8), diag=True)
+# model = LaplaceRFM(bandwidth=1., diag=False)
+model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=1.0), diag=True)
 
 n = 4000 # samples
 d = 4  # dimension

--- a/test.py
+++ b/test.py
@@ -14,11 +14,11 @@ def fstar(X):
     	    axis=1
         ).float()
 
-# model = LaplaceRFM(bandwidth=1., diag=False)
+# model = LaplaceRFM(bandwidth=1., diag=True)
 model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=1.0), diag=True)
 
 n = 4000 # samples
-d = 4  # dimension
+d = 100  # dimension
 c = 2    # classes
 
 X_train = torch.randn(n, d)

--- a/test.py
+++ b/test.py
@@ -1,17 +1,24 @@
+import numpy as np
 import torch
 from rfm import LaplaceRFM
+from rfm.kernels_new import LaplaceKernel
+from rfm.recursive_feature_machine import GenericRFM
+
+np.random.seed(0)
+torch.manual_seed(0)
 
 def fstar(X):
     return torch.cat([
-            (X[:, 0]  > 0)[:,None], 
+            (X[:, 0]  > 0)[:,None],
     	    (X[:, 1] < 0.5)[:, None]], 
     	    axis=1
         ).float()
 
-model =LaplaceRFM(bandwidth=1.)
+model = LaplaceRFM(bandwidth=1., diag=False)
+# model = GenericRFM(LaplaceKernel(bandwidth=1., exponent=0.8), diag=True)
 
 n = 4000 # samples
-d = 100  # dimension
+d = 4  # dimension
 c = 2    # classes
 
 X_train = torch.randn(n, d)


### PR DESCRIPTION
Includes
- a Kernel base class that takes care of handling M and diag/non-diag AGOP
- GenericRFM, which works with any Kernel subclass
- Short implementations of L1 and L2 Laplace kernels on top of the Kernel base class, with a more memory- and time-efficient implementation for the L1 Laplace kernel.