### PR TITLE
Fix matrix power failure cases by running it on CPU

### DIFF
--- a/rfm/utils.py
+++ b/rfm/utils.py
@@ -32,7 +32,7 @@ def matrix_power(M, power):
             sqrtM = sqrtm(M_cpu)
         else:
             sqrtM = fractional_matrix_power(M_cpu, power)
-        sqrtM = torch.from_numpy(sqrtM).to(M.device)
+        sqrtM = torch.as_tensor(sqrtM, dtype=torch.float32, device=M.device)
         return sqrtM
 
     elif len(M.shape) == 1:

--- a/rfm/utils.py
+++ b/rfm/utils.py
@@ -18,9 +18,23 @@ def matrix_power(M, power):
         assert M.shape[0] == M.shape[1], "Matrix must be square"
 
         # gpu square root
-        S, U = torch.linalg.eigh(M)
-        S[S<0] = 0.
-        return U @ torch.diag(S**power) @ U.T
+        # S, U = torch.linalg.eigh(M)
+        # S[S<0] = 0.
+        # return U @ torch.diag(S**power) @ U.T
+
+        # CPU square root to avoid rare bugs
+        # cannot try GPU eigh first because it can still run into bugs even with a try/except
+        # https://github.com/pytorch/pytorch/issues/105359
+        M_cpu = M.cpu().clone()
+        # 1e-8 was perhaps too small in some failure case where all entries of M were identical
+        M_cpu.diagonal().add_(1e-6)
+        if power == 0.5:
+            sqrtM = sqrtm(M_cpu)
+        else:
+            sqrtM = fractional_matrix_power(M_cpu, power)
+        sqrtM = torch.from_numpy(sqrtM).to(M.device)
+        return sqrtM
+
     elif len(M.shape) == 1:
         assert M.shape[0] > 0, "Vector must be non-empty"
         M[M<0] = 0.


### PR DESCRIPTION
The matrix power by running torch.linalg.eigh on GPU failed in some cases, in a way that was not recoverable by using try/except thanks to this bug: https://github.com/pytorch/pytorch/issues/105359

I changed it to CPU only for now, using scipy, and adding a small term to the diagonal to avoid some convergence issues in corner cases.